### PR TITLE
`TraceService.getActiveSpan()` may return `null`

### DIFF
--- a/src/trace.service.ts
+++ b/src/trace.service.ts
@@ -7,7 +7,7 @@ export class TraceService {
     return tracer;
   }
 
-  public getActiveSpan(): Span {
+  public getActiveSpan(): Span | null {
     return tracer.scope().active();
   }
 }


### PR DESCRIPTION
Hello.

When tracing is disabled, `TraceService.getActiveSpan()` returns `null`.

This is due to `Scope.active()` returning `Span | null`, because tracing is disabled.

```typescript
export declare interface Scope {
  /**
   * Get the current active span or null if there is none.
   *
   * @returns {Span} The active span.
   */
  active(): Span | null;
```

This PR fixes type declaration for return value.

This change affects all code that uses `getActiveSpan()` span:

```
span.setTag('foo', 'bar')
```
needs to be changed to:

```
span?.setTag('foo', 'bar')
```

This way the TS code matches Datadog behavior and allows to write proper code