### PR TITLE
Import tracer as default import from dd-trace

### DIFF
--- a/src/decorator.injector.ts
+++ b/src/decorator.injector.ts
@@ -3,7 +3,7 @@ import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
 import { Constants } from './constants';
 import { MetadataScanner, ModulesContainer } from '@nestjs/core';
 import { Controller, Injectable as InjectableInterface } from '@nestjs/common/interfaces';
-import { tracer, Span } from 'dd-trace';
+import tracer, { Span } from 'dd-trace';
 import { Injector } from './injector.interface';
 
 @Injectable()


### PR DESCRIPTION
Fixes #15 

Let me know if I don't understand the full implications for this change. But I've tested this in a commonjs module and ES Module and works fine. Tests also passing.