### PR TITLE
chore: allow dd-trace@4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nestjs-ddtrace",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nestjs-ddtrace",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "devDependencies": {
         "@nestjs/cli": "^9.0.0",
@@ -38,7 +38,7 @@
       "peerDependencies": {
         "@nestjs/common": "^9.0.0",
         "@nestjs/core": "^9.0.0",
-        "dd-trace": "^3.0.0"
+        "dd-trace": ">=3.0.0 < 5"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-ddtrace",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "NestJS Datadog Trace Library",
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "@nestjs/common": "^9.0.0",
     "@nestjs/core": "^9.0.0",
-    "dd-trace": "^3.0.0"
+    "dd-trace": ">=3.0.0 < 5"
   },
   "devDependencies": {
     "@nestjs/cli": "^9.0.0",


### PR DESCRIPTION
Since this is a peer dep, we can just allow v4, as it contains no breaking changes for this module.