### PR TITLE
update dd-trace to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
       "peerDependencies": {
         "@nestjs/common": "^10.1.3",
         "@nestjs/core": "^10.1.3",
-        "dd-trace": "^4"
+        "dd-trace": "^5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -858,34 +858,44 @@
       }
     },
     "node_modules/@datadog/native-appsec": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-3.2.0.tgz",
-      "integrity": "sha512-biAa7EFfuavjSWgSQaCit9CqGzr6Af5nhzfNNGJ38Y/Y387hDvLivAR374kK1z6XoxGZEOa+XPbVogmV/2Bcjw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-7.0.0.tgz",
+      "integrity": "sha512-bywstWFW2hWxzPuS0+mFMVHHL0geulx5yQFtsjfszaH2LTAgk2D+Rt40MKbAoZ8q3tRw2dy6aYQ7svO3ca8jpA==",
       "hasInstallScript": true,
       "peer": true,
       "dependencies": {
         "node-gyp-build": "^3.9.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@datadog/native-iast-rewriter": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.0.1.tgz",
-      "integrity": "sha512-Mm+FG3XxEbPrAfJQPOMHts7iZZXRvg9gnGeeFRGkyirmRcQcOpZO4wFe/8K61DUVa5pXpgAJQ2ZkBGYF1O9STg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.2.2.tgz",
+      "integrity": "sha512-13ZBhJpjZ/tiV6rYfyAf/ITye9cyd3x12M/2NKhD4Ivev4N4uKBREAjpArOtzKtPXZ5b6oXwVV4ofT1SHoYyzA==",
       "peer": true,
       "dependencies": {
+        "lru-cache": "^7.14.0",
         "node-gyp-build": "^4.5.0"
       },
       "engines": {
         "node": ">= 10"
       }
     },
+    "node_modules/@datadog/native-iast-rewriter/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@datadog/native-iast-rewriter/node_modules/node-gyp-build": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
-      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
+      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
       "peer": true,
       "bin": {
         "node-gyp-build": "bin.js",
@@ -894,9 +904,10 @@
       }
     },
     "node_modules/@datadog/native-iast-taint-tracking": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.5.0.tgz",
-      "integrity": "sha512-SOWIk1M6PZH0osNB191Voz2rKBPoF5hISWVSK9GiJPrD40+xjib1Z/bFDV7EkDn3kjOyordSBdNPG5zOqZJdyg==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.6.4.tgz",
+      "integrity": "sha512-Owxk7hQ4Dxwv4zJAoMjRga0IvE6lhvxnNc8pJCHsemCWBXchjr/9bqg05Zy5JnMbKUWn4XuZeJD6RFZpRa8bfw==",
+      "hasInstallScript": true,
       "peer": true,
       "dependencies": {
         "node-gyp-build": "^3.9.0"
@@ -917,9 +928,9 @@
       }
     },
     "node_modules/@datadog/pprof": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-3.1.0.tgz",
-      "integrity": "sha512-Bg8O8yrHeL2KKHXhLoAAT33ZfzLnZ6rWfOjy8PkcNhUJy3UwNVLbUoApf+99EyLjqpzpk/kZXrIAMBzMMB8ilg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.0.0.tgz",
+      "integrity": "sha512-vhNan4SBuNWLpexunDJQ+hNbRAgWdk2qy5Iyh7Nn94uSSHXigAJMAvu4jwMKKQKFfchtobOkWT8GQUWW3tgpFg==",
       "hasInstallScript": true,
       "peer": true,
       "dependencies": {
@@ -930,7 +941,7 @@
         "source-map": "^0.7.4"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@datadog/sketches-js": {
@@ -3711,34 +3722,41 @@
       "integrity": "sha512-/RC5F4l1SCqD/jazwUF6+t34Cd8zTSAGZ7rvvZu1whZUhD2a5MOGKjSGowoGcpj/cbVZk1ZODIooJEQQq3nNAA==",
       "peer": true
     },
+    "node_modules/dc-polyfill": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/dc-polyfill/-/dc-polyfill-0.1.3.tgz",
+      "integrity": "sha512-Wyk5n/5KUj3GfVKV2jtDbtChC/Ff9fjKsBcg4ZtYW1yQe3DXNHcGURvmoxhqQdfOQ9TwyMjnfyv1lyYcOkFkFA==",
+      "peer": true,
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/dd-trace": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-4.12.0.tgz",
-      "integrity": "sha512-QAvlKWUn8Tx75hbos7d7hk/9iCo3tKShd3vGg4mMtl3YWYZd7wsYUtX1PJUS+CjQgOPh2XJuBLAGYoamYYTeBg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.2.0.tgz",
+      "integrity": "sha512-Z5ql3ZKzVW3DPstHPkTPcIPvKljHNtzTYY/WuZRlgT4XK7rMaN0j5nA8LlUh7m+tOPWs05IiKngbYVZjsqhRgA==",
       "hasInstallScript": true,
       "peer": true,
       "dependencies": {
-        "@datadog/native-appsec": "^3.2.0",
-        "@datadog/native-iast-rewriter": "2.0.1",
-        "@datadog/native-iast-taint-tracking": "1.5.0",
+        "@datadog/native-appsec": "7.0.0",
+        "@datadog/native-iast-rewriter": "2.2.2",
+        "@datadog/native-iast-taint-tracking": "1.6.4",
         "@datadog/native-metrics": "^2.0.0",
-        "@datadog/pprof": "3.1.0",
+        "@datadog/pprof": "5.0.0",
         "@datadog/sketches-js": "^2.1.0",
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/core": "^1.14.0",
         "crypto-randomuuid": "^1.0.0",
-        "diagnostics_channel": "^1.1.0",
+        "dc-polyfill": "^0.1.2",
         "ignore": "^5.2.4",
-        "import-in-the-middle": "^1.4.2",
+        "import-in-the-middle": "^1.7.3",
         "int64-buffer": "^0.1.9",
         "ipaddr.js": "^2.1.0",
         "istanbul-lib-coverage": "3.2.0",
+        "jest-docblock": "^29.7.0",
         "koalas": "^1.0.2",
-        "limiter": "^1.1.4",
-        "lodash.kebabcase": "^4.1.1",
-        "lodash.pick": "^4.4.0",
+        "limiter": "1.1.5",
         "lodash.sortby": "^4.7.0",
-        "lodash.uniq": "^4.5.0",
         "lru-cache": "^7.14.0",
         "methods": "^1.1.2",
         "module-details-from-path": "^1.0.3",
@@ -3746,12 +3764,14 @@
         "node-abort-controller": "^3.1.1",
         "opentracing": ">=0.12.1",
         "path-to-regexp": "^0.1.2",
-        "protobufjs": "^7.2.4",
+        "pprof-format": "^2.0.7",
+        "protobufjs": "^7.2.5",
         "retry": "^0.13.1",
-        "semver": "^7.5.4"
+        "semver": "^7.5.4",
+        "tlhunter-sorted-set": "^0.1.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/dd-trace/node_modules/lru-cache": {
@@ -4031,7 +4051,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4044,15 +4063,6 @@
       "dependencies": {
         "asap": "^2.0.0",
         "wrappy": "1"
-      }
-    },
-    "node_modules/diagnostics_channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/diagnostics_channel/-/diagnostics_channel-1.1.0.tgz",
-      "integrity": "sha512-OE1ngLDjSBPG6Tx0YATELzYzy3RKHC+7veQ8gLa8yS7AAgw65mFbVdcsu3501abqOZCEZqZyAIemB0zXlqDSuw==",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/diff": {
@@ -5329,9 +5339,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
-      "integrity": "sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.3.tgz",
+      "integrity": "sha512-R2I11NRi0lI3jD2+qjqyVlVEahsejw7LDnYEbGb47QEFjczE3bZYsmWheCTQA+LFs2DzOQxR7Pms7naHW1V4bQ==",
       "peer": true,
       "dependencies": {
         "acorn": "^8.8.2",
@@ -5901,10 +5911,9 @@
       }
     },
     "node_modules/jest-docblock": {
-      "version": "29.4.3",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.4.3.tgz",
-      "integrity": "sha512-fzdTftThczeSD9nZ3fzA/4KkHtnmllawWrXO69vtI+L9WjEIuXWs4AmyME7lN5hU7dB0sHhuPfcKofRsUb/2Fg==",
-      "dev": true,
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
       "dependencies": {
         "detect-newline": "^3.0.0"
       },
@@ -6470,12 +6479,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "node_modules/lodash.kebabcase": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
-      "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
-      "peer": true
-    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -6488,22 +6491,10 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
-    "node_modules/lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
-      "peer": true
-    },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-      "peer": true
-    },
-    "node_modules/lodash.uniq": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "peer": true
     },
     "node_modules/log-symbols": {
@@ -7428,9 +7419,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
-      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
       "hasInstallScript": true,
       "peer": true,
       "dependencies": {
@@ -8548,6 +8539,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/tlhunter-sorted-set": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tlhunter-sorted-set/-/tlhunter-sorted-set-0.1.0.tgz",
+      "integrity": "sha512-eGYW4bjf1DtrHzUYxYfAcSytpOkA44zsr7G2n3PV7yOUR23vmkGe3LL4R+1jL9OsXtbsFOwe8XtbCrabeaEFnw==",
+      "peer": true
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -9905,35 +9902,42 @@
       }
     },
     "@datadog/native-appsec": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-3.2.0.tgz",
-      "integrity": "sha512-biAa7EFfuavjSWgSQaCit9CqGzr6Af5nhzfNNGJ38Y/Y387hDvLivAR374kK1z6XoxGZEOa+XPbVogmV/2Bcjw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-7.0.0.tgz",
+      "integrity": "sha512-bywstWFW2hWxzPuS0+mFMVHHL0geulx5yQFtsjfszaH2LTAgk2D+Rt40MKbAoZ8q3tRw2dy6aYQ7svO3ca8jpA==",
       "peer": true,
       "requires": {
         "node-gyp-build": "^3.9.0"
       }
     },
     "@datadog/native-iast-rewriter": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.0.1.tgz",
-      "integrity": "sha512-Mm+FG3XxEbPrAfJQPOMHts7iZZXRvg9gnGeeFRGkyirmRcQcOpZO4wFe/8K61DUVa5pXpgAJQ2ZkBGYF1O9STg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.2.2.tgz",
+      "integrity": "sha512-13ZBhJpjZ/tiV6rYfyAf/ITye9cyd3x12M/2NKhD4Ivev4N4uKBREAjpArOtzKtPXZ5b6oXwVV4ofT1SHoYyzA==",
       "peer": true,
       "requires": {
+        "lru-cache": "^7.14.0",
         "node-gyp-build": "^4.5.0"
       },
       "dependencies": {
+        "lru-cache": {
+          "version": "7.18.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+          "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+          "peer": true
+        },
         "node-gyp-build": {
-          "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
-          "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
+          "version": "4.8.0",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
+          "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
           "peer": true
         }
       }
     },
     "@datadog/native-iast-taint-tracking": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.5.0.tgz",
-      "integrity": "sha512-SOWIk1M6PZH0osNB191Voz2rKBPoF5hISWVSK9GiJPrD40+xjib1Z/bFDV7EkDn3kjOyordSBdNPG5zOqZJdyg==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.6.4.tgz",
+      "integrity": "sha512-Owxk7hQ4Dxwv4zJAoMjRga0IvE6lhvxnNc8pJCHsemCWBXchjr/9bqg05Zy5JnMbKUWn4XuZeJD6RFZpRa8bfw==",
       "peer": true,
       "requires": {
         "node-gyp-build": "^3.9.0"
@@ -9950,9 +9954,9 @@
       }
     },
     "@datadog/pprof": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-3.1.0.tgz",
-      "integrity": "sha512-Bg8O8yrHeL2KKHXhLoAAT33ZfzLnZ6rWfOjy8PkcNhUJy3UwNVLbUoApf+99EyLjqpzpk/kZXrIAMBzMMB8ilg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-5.0.0.tgz",
+      "integrity": "sha512-vhNan4SBuNWLpexunDJQ+hNbRAgWdk2qy5Iyh7Nn94uSSHXigAJMAvu4jwMKKQKFfchtobOkWT8GQUWW3tgpFg==",
       "peer": true,
       "requires": {
         "delay": "^5.0.0",
@@ -12016,33 +12020,37 @@
       "integrity": "sha512-/RC5F4l1SCqD/jazwUF6+t34Cd8zTSAGZ7rvvZu1whZUhD2a5MOGKjSGowoGcpj/cbVZk1ZODIooJEQQq3nNAA==",
       "peer": true
     },
+    "dc-polyfill": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/dc-polyfill/-/dc-polyfill-0.1.3.tgz",
+      "integrity": "sha512-Wyk5n/5KUj3GfVKV2jtDbtChC/Ff9fjKsBcg4ZtYW1yQe3DXNHcGURvmoxhqQdfOQ9TwyMjnfyv1lyYcOkFkFA==",
+      "peer": true
+    },
     "dd-trace": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-4.12.0.tgz",
-      "integrity": "sha512-QAvlKWUn8Tx75hbos7d7hk/9iCo3tKShd3vGg4mMtl3YWYZd7wsYUtX1PJUS+CjQgOPh2XJuBLAGYoamYYTeBg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-5.2.0.tgz",
+      "integrity": "sha512-Z5ql3ZKzVW3DPstHPkTPcIPvKljHNtzTYY/WuZRlgT4XK7rMaN0j5nA8LlUh7m+tOPWs05IiKngbYVZjsqhRgA==",
       "peer": true,
       "requires": {
-        "@datadog/native-appsec": "^3.2.0",
-        "@datadog/native-iast-rewriter": "2.0.1",
-        "@datadog/native-iast-taint-tracking": "1.5.0",
+        "@datadog/native-appsec": "7.0.0",
+        "@datadog/native-iast-rewriter": "2.2.2",
+        "@datadog/native-iast-taint-tracking": "1.6.4",
         "@datadog/native-metrics": "^2.0.0",
-        "@datadog/pprof": "3.1.0",
+        "@datadog/pprof": "5.0.0",
         "@datadog/sketches-js": "^2.1.0",
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/core": "^1.14.0",
         "crypto-randomuuid": "^1.0.0",
-        "diagnostics_channel": "^1.1.0",
+        "dc-polyfill": "^0.1.2",
         "ignore": "^5.2.4",
-        "import-in-the-middle": "^1.4.2",
+        "import-in-the-middle": "^1.7.3",
         "int64-buffer": "^0.1.9",
         "ipaddr.js": "^2.1.0",
         "istanbul-lib-coverage": "3.2.0",
+        "jest-docblock": "^29.7.0",
         "koalas": "^1.0.2",
-        "limiter": "^1.1.4",
-        "lodash.kebabcase": "^4.1.1",
-        "lodash.pick": "^4.4.0",
+        "limiter": "1.1.5",
         "lodash.sortby": "^4.7.0",
-        "lodash.uniq": "^4.5.0",
         "lru-cache": "^7.14.0",
         "methods": "^1.1.2",
         "module-details-from-path": "^1.0.3",
@@ -12050,9 +12058,11 @@
         "node-abort-controller": "^3.1.1",
         "opentracing": ">=0.12.1",
         "path-to-regexp": "^0.1.2",
-        "protobufjs": "^7.2.4",
+        "pprof-format": "^2.0.7",
+        "protobufjs": "^7.2.5",
         "retry": "^0.13.1",
-        "semver": "^7.5.4"
+        "semver": "^7.5.4",
+        "tlhunter-sorted-set": "^0.1.0"
       },
       "dependencies": {
         "lru-cache": {
@@ -12232,8 +12242,7 @@
     "detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
-      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
-      "dev": true
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA=="
     },
     "dezalgo": {
       "version": "1.0.4",
@@ -12244,12 +12253,6 @@
         "asap": "^2.0.0",
         "wrappy": "1"
       }
-    },
-    "diagnostics_channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/diagnostics_channel/-/diagnostics_channel-1.1.0.tgz",
-      "integrity": "sha512-OE1ngLDjSBPG6Tx0YATELzYzy3RKHC+7veQ8gLa8yS7AAgw65mFbVdcsu3501abqOZCEZqZyAIemB0zXlqDSuw==",
-      "peer": true
     },
     "diff": {
       "version": "4.0.2",
@@ -13215,9 +13218,9 @@
       }
     },
     "import-in-the-middle": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
-      "integrity": "sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.3.tgz",
+      "integrity": "sha512-R2I11NRi0lI3jD2+qjqyVlVEahsejw7LDnYEbGb47QEFjczE3bZYsmWheCTQA+LFs2DzOQxR7Pms7naHW1V4bQ==",
       "peer": true,
       "requires": {
         "acorn": "^8.8.2",
@@ -13619,10 +13622,9 @@
       }
     },
     "jest-docblock": {
-      "version": "29.4.3",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.4.3.tgz",
-      "integrity": "sha512-fzdTftThczeSD9nZ3fzA/4KkHtnmllawWrXO69vtI+L9WjEIuXWs4AmyME7lN5hU7dB0sHhuPfcKofRsUb/2Fg==",
-      "dev": true,
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
       "requires": {
         "detect-newline": "^3.0.0"
       }
@@ -14072,12 +14074,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "lodash.kebabcase": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
-      "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
-      "peer": true
-    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -14090,22 +14086,10 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
-    "lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
-      "peer": true
-    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-      "peer": true
-    },
-    "lodash.uniq": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "peer": true
     },
     "log-symbols": {
@@ -14794,9 +14778,9 @@
       }
     },
     "protobufjs": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
-      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
       "peer": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -15614,6 +15598,12 @@
       "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
       "integrity": "sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==",
       "dev": true
+    },
+    "tlhunter-sorted-set": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tlhunter-sorted-set/-/tlhunter-sorted-set-0.1.0.tgz",
+      "integrity": "sha512-eGYW4bjf1DtrHzUYxYfAcSytpOkA44zsr7G2n3PV7yOUR23vmkGe3LL4R+1jL9OsXtbsFOwe8XtbCrabeaEFnw==",
+      "peer": true
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "@nestjs/common": "^10.1.3",
     "@nestjs/core": "^10.1.3",
-    "dd-trace": "^4"
+    "dd-trace": "^5"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.1.11",


### PR DESCRIPTION
update dd-trace to version 5 

we are not calling tracer.trace in our code so no updated it needed

## Breaking change from dd-trace library

Update trace<T> TypeScript declaration
The TypeScript declaration for trace<T> has been updated to enforce that calls to tracer.trace(name, fn) must receive a function which takes at least the span object. Previously the span was technically optional when it should not have been as the span must be handled.

closes #27