### PR TITLE
npm prepare with npm run build

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "private": false,
   "license": "MIT",
   "scripts": {
+    "prepare": "npm run build",
     "prebuild": "rimraf lib",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",


### PR DESCRIPTION
Enables installing this npm package directly from github.

e.g.
```json
"nestjs-ddtrace": "github:codebrick-corp/nestjs-ddtrace#branch",
```