### PR TITLE
fix: handle awaiting non-async functions that return a Promise

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,8 +37,8 @@
         "typescript": "^5.7.3"
       },
       "peerDependencies": {
-        "@nestjs/common": "^10.3.3",
-        "@nestjs/core": "^10.3.3",
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/core": "^11.0.0",
         "dd-trace": "^5"
       }
     },

--- a/src/decorator.injector.ts
+++ b/src/decorator.injector.ts
@@ -190,10 +190,19 @@ export class DecoratorInjector implements Injector {
           } else {
             try {
               const result = prototype.apply(this, args);
+              // This handles the case where a function isn't async but returns a Promise
+              if (result && typeof result.then === 'function') {
+                return result
+                  .catch((error) => {
+                    DecoratorInjector.recordException(error, span);
+                  })
+                  .finally(() => span.finish());
+              }
+
+              span.finish();
               return result;
             } catch (error) {
               DecoratorInjector.recordException(error, span);
-            } finally {
               span.finish();
             }
           }


### PR DESCRIPTION
Currently if you have a function that returns a `Promise` but is not marked as async, this library treats it as synchronous and immediately closes the span without awaiting the `Promise`.

This PR makes the library handle this case the same way that `dd-trace-js` does it (see https://github.com/DataDog/dd-trace-js/blob/2072a1f0e75c7b921d3c09dc9cc72c1779cbbddd/packages/dd-trace/src/tracer.js#L81).